### PR TITLE
Implement checks for fat pointer operands and a utility function for erasure

### DIFF
--- a/src/definitions/add.rs
+++ b/src/definitions/add.rs
@@ -68,4 +68,12 @@ impl OpcodeProps for AddOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/add.rs
+++ b/src/definitions/add.rs
@@ -69,11 +69,11 @@ impl OpcodeProps for AddOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/all.rs
+++ b/src/definitions/all.rs
@@ -268,4 +268,46 @@ impl Opcode {
             Opcode::UMA(sub) => sub.output_operands(version),
         }
     }
+
+    pub fn src0_should_be_pointer(&self) -> bool {
+        match self {
+            Opcode::Invalid(sub) => sub.src0_should_be_pointer(),
+            Opcode::Nop(sub) => sub.src0_should_be_pointer(),
+            Opcode::Add(sub) => sub.src0_should_be_pointer(),
+            Opcode::Sub(sub) => sub.src0_should_be_pointer(),
+            Opcode::Mul(sub) => sub.src0_should_be_pointer(),
+            Opcode::Div(sub) => sub.src0_should_be_pointer(),
+            Opcode::Jump(sub) => sub.src0_should_be_pointer(),
+            Opcode::Context(sub) => sub.src0_should_be_pointer(),
+            Opcode::Shift(sub) => sub.src0_should_be_pointer(),
+            Opcode::Binop(sub) => sub.src0_should_be_pointer(),
+            Opcode::Ptr(sub) => sub.src0_should_be_pointer(),
+            Opcode::NearCall(sub) => sub.src0_should_be_pointer(),
+            Opcode::Log(sub) => sub.src0_should_be_pointer(),
+            Opcode::FarCall(sub) => sub.src0_should_be_pointer(),
+            Opcode::Ret(sub) => sub.src0_should_be_pointer(),
+            Opcode::UMA(sub) => sub.src0_should_be_pointer(),
+        }
+    }
+
+    pub fn src1_should_be_pointer(&self) -> bool {
+        match self {
+            Opcode::Invalid(sub) => sub.src1_should_be_pointer(),
+            Opcode::Nop(sub) => sub.src1_should_be_pointer(),
+            Opcode::Add(sub) => sub.src1_should_be_pointer(),
+            Opcode::Sub(sub) => sub.src1_should_be_pointer(),
+            Opcode::Mul(sub) => sub.src1_should_be_pointer(),
+            Opcode::Div(sub) => sub.src1_should_be_pointer(),
+            Opcode::Jump(sub) => sub.src1_should_be_pointer(),
+            Opcode::Context(sub) => sub.src1_should_be_pointer(),
+            Opcode::Shift(sub) => sub.src1_should_be_pointer(),
+            Opcode::Binop(sub) => sub.src1_should_be_pointer(),
+            Opcode::Ptr(sub) => sub.src1_should_be_pointer(),
+            Opcode::NearCall(sub) => sub.src1_should_be_pointer(),
+            Opcode::Log(sub) => sub.src1_should_be_pointer(),
+            Opcode::FarCall(sub) => sub.src1_should_be_pointer(),
+            Opcode::Ret(sub) => sub.src1_should_be_pointer(),
+            Opcode::UMA(sub) => sub.src1_should_be_pointer(),
+        }
+    }
 }

--- a/src/definitions/all.rs
+++ b/src/definitions/all.rs
@@ -269,45 +269,45 @@ impl Opcode {
         }
     }
 
-    pub fn src0_should_be_pointer(&self) -> bool {
+    pub fn src0_can_be_pointer(&self) -> bool {
         match self {
-            Opcode::Invalid(sub) => sub.src0_should_be_pointer(),
-            Opcode::Nop(sub) => sub.src0_should_be_pointer(),
-            Opcode::Add(sub) => sub.src0_should_be_pointer(),
-            Opcode::Sub(sub) => sub.src0_should_be_pointer(),
-            Opcode::Mul(sub) => sub.src0_should_be_pointer(),
-            Opcode::Div(sub) => sub.src0_should_be_pointer(),
-            Opcode::Jump(sub) => sub.src0_should_be_pointer(),
-            Opcode::Context(sub) => sub.src0_should_be_pointer(),
-            Opcode::Shift(sub) => sub.src0_should_be_pointer(),
-            Opcode::Binop(sub) => sub.src0_should_be_pointer(),
-            Opcode::Ptr(sub) => sub.src0_should_be_pointer(),
-            Opcode::NearCall(sub) => sub.src0_should_be_pointer(),
-            Opcode::Log(sub) => sub.src0_should_be_pointer(),
-            Opcode::FarCall(sub) => sub.src0_should_be_pointer(),
-            Opcode::Ret(sub) => sub.src0_should_be_pointer(),
-            Opcode::UMA(sub) => sub.src0_should_be_pointer(),
+            Opcode::Invalid(sub) => sub.src0_can_be_pointer(),
+            Opcode::Nop(sub) => sub.src0_can_be_pointer(),
+            Opcode::Add(sub) => sub.src0_can_be_pointer(),
+            Opcode::Sub(sub) => sub.src0_can_be_pointer(),
+            Opcode::Mul(sub) => sub.src0_can_be_pointer(),
+            Opcode::Div(sub) => sub.src0_can_be_pointer(),
+            Opcode::Jump(sub) => sub.src0_can_be_pointer(),
+            Opcode::Context(sub) => sub.src0_can_be_pointer(),
+            Opcode::Shift(sub) => sub.src0_can_be_pointer(),
+            Opcode::Binop(sub) => sub.src0_can_be_pointer(),
+            Opcode::Ptr(sub) => sub.src0_can_be_pointer(),
+            Opcode::NearCall(sub) => sub.src0_can_be_pointer(),
+            Opcode::Log(sub) => sub.src0_can_be_pointer(),
+            Opcode::FarCall(sub) => sub.src0_can_be_pointer(),
+            Opcode::Ret(sub) => sub.src0_can_be_pointer(),
+            Opcode::UMA(sub) => sub.src0_can_be_pointer(),
         }
     }
 
-    pub fn src1_should_be_pointer(&self) -> bool {
+    pub fn src1_can_be_pointer(&self) -> bool {
         match self {
-            Opcode::Invalid(sub) => sub.src1_should_be_pointer(),
-            Opcode::Nop(sub) => sub.src1_should_be_pointer(),
-            Opcode::Add(sub) => sub.src1_should_be_pointer(),
-            Opcode::Sub(sub) => sub.src1_should_be_pointer(),
-            Opcode::Mul(sub) => sub.src1_should_be_pointer(),
-            Opcode::Div(sub) => sub.src1_should_be_pointer(),
-            Opcode::Jump(sub) => sub.src1_should_be_pointer(),
-            Opcode::Context(sub) => sub.src1_should_be_pointer(),
-            Opcode::Shift(sub) => sub.src1_should_be_pointer(),
-            Opcode::Binop(sub) => sub.src1_should_be_pointer(),
-            Opcode::Ptr(sub) => sub.src1_should_be_pointer(),
-            Opcode::NearCall(sub) => sub.src1_should_be_pointer(),
-            Opcode::Log(sub) => sub.src1_should_be_pointer(),
-            Opcode::FarCall(sub) => sub.src1_should_be_pointer(),
-            Opcode::Ret(sub) => sub.src1_should_be_pointer(),
-            Opcode::UMA(sub) => sub.src1_should_be_pointer(),
+            Opcode::Invalid(sub) => sub.src1_can_be_pointer(),
+            Opcode::Nop(sub) => sub.src1_can_be_pointer(),
+            Opcode::Add(sub) => sub.src1_can_be_pointer(),
+            Opcode::Sub(sub) => sub.src1_can_be_pointer(),
+            Opcode::Mul(sub) => sub.src1_can_be_pointer(),
+            Opcode::Div(sub) => sub.src1_can_be_pointer(),
+            Opcode::Jump(sub) => sub.src1_can_be_pointer(),
+            Opcode::Context(sub) => sub.src1_can_be_pointer(),
+            Opcode::Shift(sub) => sub.src1_can_be_pointer(),
+            Opcode::Binop(sub) => sub.src1_can_be_pointer(),
+            Opcode::Ptr(sub) => sub.src1_can_be_pointer(),
+            Opcode::NearCall(sub) => sub.src1_can_be_pointer(),
+            Opcode::Log(sub) => sub.src1_can_be_pointer(),
+            Opcode::FarCall(sub) => sub.src1_can_be_pointer(),
+            Opcode::Ret(sub) => sub.src1_can_be_pointer(),
+            Opcode::UMA(sub) => sub.src1_can_be_pointer(),
         }
     }
 }

--- a/src/definitions/binop.rs
+++ b/src/definitions/binop.rs
@@ -73,11 +73,11 @@ impl OpcodeProps for BinopOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/binop.rs
+++ b/src/definitions/binop.rs
@@ -72,4 +72,12 @@ impl OpcodeProps for BinopOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/context.rs
+++ b/src/definitions/context.rs
@@ -124,4 +124,12 @@ impl OpcodeProps for ContextOpcode {
             _ => true,
         }
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/context.rs
+++ b/src/definitions/context.rs
@@ -125,11 +125,11 @@ impl OpcodeProps for ContextOpcode {
         }
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/div.rs
+++ b/src/definitions/div.rs
@@ -69,11 +69,11 @@ impl OpcodeProps for DivOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/div.rs
+++ b/src/definitions/div.rs
@@ -68,4 +68,12 @@ impl OpcodeProps for DivOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/far_call.rs
+++ b/src/definitions/far_call.rs
@@ -97,11 +97,11 @@ impl OpcodeProps for FarCallOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         true
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/far_call.rs
+++ b/src/definitions/far_call.rs
@@ -96,4 +96,12 @@ impl OpcodeProps for FarCallOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        true
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/invalid_opcode.rs
+++ b/src/definitions/invalid_opcode.rs
@@ -62,4 +62,12 @@ impl OpcodeProps for InvalidOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/invalid_opcode.rs
+++ b/src/definitions/invalid_opcode.rs
@@ -63,11 +63,11 @@ impl OpcodeProps for InvalidOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/jump.rs
+++ b/src/definitions/jump.rs
@@ -63,11 +63,11 @@ impl OpcodeProps for JumpOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/jump.rs
+++ b/src/definitions/jump.rs
@@ -62,4 +62,12 @@ impl OpcodeProps for JumpOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/log.rs
+++ b/src/definitions/log.rs
@@ -171,4 +171,12 @@ impl OpcodeProps for LogOpcode {
             _ => true,
         }
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/log.rs
+++ b/src/definitions/log.rs
@@ -172,11 +172,11 @@ impl OpcodeProps for LogOpcode {
         }
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/mul.rs
+++ b/src/definitions/mul.rs
@@ -69,11 +69,11 @@ impl OpcodeProps for MulOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/mul.rs
+++ b/src/definitions/mul.rs
@@ -68,4 +68,12 @@ impl OpcodeProps for MulOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/near_call.rs
+++ b/src/definitions/near_call.rs
@@ -63,11 +63,11 @@ impl OpcodeProps for NearCallOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/near_call.rs
+++ b/src/definitions/near_call.rs
@@ -62,4 +62,12 @@ impl OpcodeProps for NearCallOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/noop.rs
+++ b/src/definitions/noop.rs
@@ -62,4 +62,12 @@ impl OpcodeProps for NopOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/noop.rs
+++ b/src/definitions/noop.rs
@@ -63,11 +63,11 @@ impl OpcodeProps for NopOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/opcode_trait.rs
+++ b/src/definitions/opcode_trait.rs
@@ -83,8 +83,8 @@ pub trait OpcodeProps: 'static + Send + Sync {
             }
         }
     }
-    fn src0_should_be_pointer(&self) -> bool;
-    fn src1_should_be_pointer(&self) -> bool;
+    fn src0_can_be_pointer(&self) -> bool;
+    fn src1_can_be_pointer(&self) -> bool;
 }
 
 pub trait OpcodeVariantProps: Sized + 'static + Send + Sync {

--- a/src/definitions/opcode_trait.rs
+++ b/src/definitions/opcode_trait.rs
@@ -83,6 +83,8 @@ pub trait OpcodeProps: 'static + Send + Sync {
             }
         }
     }
+    fn src0_should_be_pointer(&self) -> bool;
+    fn src1_should_be_pointer(&self) -> bool;
 }
 
 pub trait OpcodeVariantProps: Sized + 'static + Send + Sync {

--- a/src/definitions/ptr.rs
+++ b/src/definitions/ptr.rs
@@ -83,11 +83,11 @@ impl OpcodeProps for PtrOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         true
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/ptr.rs
+++ b/src/definitions/ptr.rs
@@ -82,4 +82,12 @@ impl OpcodeProps for PtrOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        true
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/ret.rs
+++ b/src/definitions/ret.rs
@@ -79,4 +79,12 @@ impl OpcodeProps for RetOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        true
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/ret.rs
+++ b/src/definitions/ret.rs
@@ -80,11 +80,11 @@ impl OpcodeProps for RetOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         true
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/shift.rs
+++ b/src/definitions/shift.rs
@@ -79,4 +79,12 @@ impl OpcodeProps for ShiftOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/shift.rs
+++ b/src/definitions/shift.rs
@@ -80,11 +80,11 @@ impl OpcodeProps for ShiftOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/sub.rs
+++ b/src/definitions/sub.rs
@@ -68,4 +68,12 @@ impl OpcodeProps for SubOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        false
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/sub.rs
+++ b/src/definitions/sub.rs
@@ -69,11 +69,11 @@ impl OpcodeProps for SubOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         false
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/definitions/uma.rs
+++ b/src/definitions/uma.rs
@@ -139,4 +139,12 @@ impl OpcodeProps for UMAOpcode {
     fn can_be_used_in_static_context(&self) -> bool {
         true
     }
+
+    fn src0_should_be_pointer(&self) -> bool {
+        true
+    }
+
+    fn src1_should_be_pointer(&self) -> bool {
+        false
+    }
 }

--- a/src/definitions/uma.rs
+++ b/src/definitions/uma.rs
@@ -140,11 +140,11 @@ impl OpcodeProps for UMAOpcode {
         true
     }
 
-    fn src0_should_be_pointer(&self) -> bool {
+    fn src0_can_be_pointer(&self) -> bool {
         true
     }
 
-    fn src1_should_be_pointer(&self) -> bool {
+    fn src1_can_be_pointer(&self) -> bool {
         false
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,9 +66,9 @@ pub fn bytecode_to_code_hash_for_mode<const N: usize, E: VmEncodingMode<N>>(
 pub fn erase_fat_pointer_metadata(ptr: &mut U256) {
     // Memory page is at 1<<32 - 1<<64, start is at 1<<64 - 1<<96
     // We also need to preserve the top 128 bits of the value
-    let low_bits = ptr.low_u128() & 0xffffffff0000000000000000ffffffffu128;
-    let mut tmp = U256::from(u128::MAX);
-    tmp <<= 128;
-    tmp |= U256::from(low_bits);
-    *ptr &= tmp;
+    let low_bits = 0xffffffff0000000000000000ffffffffu128;
+    let mut mask = U256::from(u128::MAX);
+    mask <<= 128;
+    mask |= U256::from(low_bits);
+    *ptr &= mask;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,9 +66,6 @@ pub fn bytecode_to_code_hash_for_mode<const N: usize, E: VmEncodingMode<N>>(
 pub fn erase_fat_pointer_metadata(ptr: &mut U256) {
     // Memory page is at 1<<32 - 1<<64, start is at 1<<64 - 1<<96
     // We also need to preserve the top 128 bits of the value
-    let low_bits = 0xffffffff0000000000000000ffffffffu128;
-    let mut mask = U256::from(u128::MAX);
-    mask <<= 128;
-    mask |= U256::from(low_bits);
-    *ptr &= mask;
+    ptr.0[0] &= 0x00000000_ffffffffu64;
+    ptr.0[1] &= 0xffffffff_00000000u64;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use crate::decoding::{EncodingModeProduction, VmEncodingMode};
+use ethereum_types::U256;
 
 pub const fn split_as_u4(value: u8) -> (u8, u8) {
     (value & ((1u8 << 4) - 1), value >> 4)
@@ -58,4 +59,11 @@ pub fn bytecode_to_code_hash_for_mode<const N: usize, E: VmEncodingMode<N>>(
     let versioned_hash_bytes = versioned_hash.serialize().ok_or(())?;
 
     Ok(versioned_hash_bytes)
+}
+
+/// Erase start and page number from a fat pointer. To be used in the case of a fat pointer
+/// being passed to an opcode which shouldn't receive one.
+pub fn erase_fat_pointer_metadata(ptr: &mut U256) {
+    // Memory page is at 1<<32 - 1<<64, start is at 1<<64 - 1<<96
+    *ptr &= U256::from(0xffffffff0000000000000000ffffffffu128);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -65,5 +65,10 @@ pub fn bytecode_to_code_hash_for_mode<const N: usize, E: VmEncodingMode<N>>(
 /// being passed to an opcode which shouldn't receive one.
 pub fn erase_fat_pointer_metadata(ptr: &mut U256) {
     // Memory page is at 1<<32 - 1<<64, start is at 1<<64 - 1<<96
-    *ptr &= U256::from(0xffffffff0000000000000000ffffffffu128);
+    // We also need to preserve the top 128 bits of the value
+    let low_bits = ptr.low_u128() & 0xffffffff0000000000000000ffffffffu128;
+    let mut tmp = U256::from(u128::MAX);
+    tmp <<= 128;
+    tmp |= U256::from(low_bits);
+    *ptr &= tmp;
 }


### PR DESCRIPTION
# What ❔

Implement checks for fat pointer operands and a utility function for erasure.

## Why ❔

Some opcodes should not have access to some fields of a fat pointer in case they were passed in. This PR provides functionality to prevent this.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
