### PR TITLE
Ensure log.precompile takes 2 args instead of 1

### DIFF
--- a/src/definitions/log.rs
+++ b/src/definitions/log.rs
@@ -145,11 +145,13 @@ impl OpcodeProps for LogOpcode {
     }
     fn input_operands(&self, _version: ISAVersion) -> Vec<Operand> {
         match self {
-            LogOpcode::StorageWrite | LogOpcode::Event | LogOpcode::ToL1Message => {
+            LogOpcode::StorageWrite
+            | LogOpcode::Event
+            | LogOpcode::ToL1Message
+            | LogOpcode::PrecompileCall => {
                 vec![Operand::RegOnly, Operand::RegOnly]
             }
             LogOpcode::StorageRead => vec![Operand::RegOnly],
-            LogOpcode::PrecompileCall => vec![Operand::RegOnly],
         }
     }
     fn output_operands(&self, _version: ISAVersion) -> Vec<Operand> {


### PR DESCRIPTION
# What ❔

`log.precompile` calls need to take in 2 arguments instead of 1.

## Why ❔

VM Spec

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
