### PR TITLE
pinned crypto deps to github tags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/circuit_pricing_generator/main.rs"
 bitflags = "2"
 lazy_static = "1.4"
 ethereum-types = "=0.14.1"
-sha2 = "=0.10.6"
-sha3 = "=0.10.6"
-blake2 = "=0.10.6"
+sha2 = { git = "https://github.com/RustCrypto/hashes.git", tag = "sha2-v0.10.6" }
+sha3 = { git = "https://github.com/RustCrypto/hashes.git", tag = "sha3-v0.10.6" }
+blake2 = { git = "https://github.com/RustCrypto/hashes.git", tag = "blake2-v0.10.6" }
 k256 = { version = "=0.11.6", features = ["arithmetic", "ecdsa"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/circuit_pricing_generator/main.rs"
 bitflags = "2"
 lazy_static = "1.4"
 ethereum-types = "=0.14.1"
-sha2 = { git = "https://github.com/RustCrypto/hashes.git", tag = "sha2-v0.10.6" }
-sha3 = { git = "https://github.com/RustCrypto/hashes.git", tag = "sha3-v0.10.6" }
-blake2 = { git = "https://github.com/RustCrypto/hashes.git", tag = "blake2-v0.10.6" }
-k256 = { git = "https://github.com/RustCrypto/elliptic-curves.git", tag = "k256/v0.11.6" , features = ["arithmetic", "ecdsa"] }
+sha2 = { git = "https://github.com/RustCrypto/hashes.git", rev = "1731ced4a116d61ba9dc6ee6d0f38fb8102e357a" }
+sha3 = { git = "https://github.com/RustCrypto/hashes.git", rev = "7a187e934c1f6c68e4b4e5cf37541b7a0d64d303" }
+blake2 = { git = "https://github.com/RustCrypto/hashes.git", rev = "1f727ce37ff40fa0cce84eb8543a45bdd3ca4a4e" }
+k256 = { version = "0.11.6", features = ["arithmetic", "ecdsa"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ ethereum-types = "=0.14.1"
 sha2 = { git = "https://github.com/RustCrypto/hashes.git", tag = "sha2-v0.10.6" }
 sha3 = { git = "https://github.com/RustCrypto/hashes.git", tag = "sha3-v0.10.6" }
 blake2 = { git = "https://github.com/RustCrypto/hashes.git", tag = "blake2-v0.10.6" }
-k256 = { version = "=0.11.6", features = ["arithmetic", "ecdsa"] }
+k256 = { git = "https://github.com/RustCrypto/elliptic-curves.git", tag = "k256/v0.11.6" , features = ["arithmetic", "ecdsa"] }

--- a/deny.toml
+++ b/deny.toml
@@ -72,7 +72,7 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/RustCrypto/hashes.git"]
 
 [sources.allow-org]
 #github = ["matter-labs"]

--- a/deny.toml
+++ b/deny.toml
@@ -74,7 +74,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
   "https://github.com/RustCrypto/hashes.git",
-  "https://github.com/RustCrypto/elliptic-curves.git",
 ]
 
 [sources.allow-org]

--- a/deny.toml
+++ b/deny.toml
@@ -72,7 +72,10 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/RustCrypto/hashes.git"]
+allow-git = [
+  "https://github.com/RustCrypto/hashes.git",
+  "https://github.com/RustCrypto/elliptic-curves.git",
+]
 
 [sources.allow-org]
 #github = ["matter-labs"]


### PR DESCRIPTION
# What

This PR replaces version pinning with github tag pinning which excludes these particular dependencies from dependency resolver analysis, therefore allowing upstream crates to depend on the newer version as well.

## Why

Cargo doesn't allow to depend on multiple semver-compatible versions of a single crate. Since this crate binds crypto libraries to 0.10.6 it is not possible to depend on newer versions upstream.
