### PR TITLE
Update heap addressing bounds and remove memory growth cost constant

### DIFF
--- a/src/definitions/abi/fat_pointer.rs
+++ b/src/definitions/abi/fat_pointer.rs
@@ -60,7 +60,7 @@ impl FatPointer {
         if of {
             exceptions.set(FatPointerValidationException::DEREF_BEYOND_HEAP_RANGE, true);
         }
-        let (_, limit_exceeded) = ((1 << 30) - 1).overflowing_sub(end_non_inclusive);
+        let (_, limit_exceeded) = (((1 << 30) - 1) as u32).overflowing_sub(end_non_inclusive);
         if limit_exceeded {
             exceptions.set(FatPointerValidationException::DEREF_BEYOND_HEAP_RANGE, true);
         }

--- a/src/definitions/abi/fat_pointer.rs
+++ b/src/definitions/abi/fat_pointer.rs
@@ -55,9 +55,13 @@ impl FatPointer {
                 true,
             );
         }
-        // start + length doesn't overflow
-        let (_, of) = self.start.overflowing_add(self.length);
+        // start + length doesn't exceed heap bound of 2^30
+        let (end_non_inclusive, of) = self.start.overflowing_add(self.length);
         if of {
+            exceptions.set(FatPointerValidationException::DEREF_BEYOND_HEAP_RANGE, true);
+        }
+        let (_, limit_exceeded) = ((1 << 30) - 1).overflowing_sub(end_non_inclusive);
+        if limit_exceeded {
             exceptions.set(FatPointerValidationException::DEREF_BEYOND_HEAP_RANGE, true);
         }
 

--- a/src/definitions/uma.rs
+++ b/src/definitions/uma.rs
@@ -3,7 +3,7 @@ use crate::circuit_prices::{RAM_PERMUTATION_COST_IN_ERGS, VM_CYCLE_COST_IN_ERGS}
 use super::*;
 use ethereum_types::U256;
 
-pub const MAX_OFFSET_TO_DEREF_LOW_U32: u32 = ((1u64 << 32) - 33) as u32;
+pub const MAX_OFFSET_TO_DEREF_LOW_U32: u32 = ((1u64 << 30) - 1) as u32;
 
 // Maximum offset which can be dereferenced. Formally we could dereference
 // exactly 1<<32 - 32, but it would trigger extra checks and overflows, and in practice

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,11 +42,6 @@ use crate::decoding::VariantMonotonicNumber;
 
 pub const OPCODES_TABLE_WIDTH: usize = 11;
 pub const CONDITIONAL_BITS_SHIFT: usize = 13;
-pub const MEMORY_GROWTH_ERGS_PER_BYTE: u32 = 1;
-
-const _: () = if MEMORY_GROWTH_ERGS_PER_BYTE != 1 {
-    panic!()
-};
 
 pub const VARIANT_AND_CONDITION_ENCODING_BITS: usize = 16;
 


### PR DESCRIPTION
# What ❔

Update heap addressing bounds and remove memory growth cost constant

## Why ❔

Changes for v1.4.1

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
