### PR TITLE
Update crypto dependencies to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/circuit_pricing_generator/main.rs"
 bitflags = "2"
 lazy_static = "1.4"
 ethereum-types = "=0.14.1"
-sha2 = "=0.10.6"
-sha3 = "=0.10.6"
-blake2 = "=0.10.6"
-k256 = { version = "=0.11.6", features = ["arithmetic", "ecdsa"] }
+sha2 = "=0.10.8"
+sha3 = "=0.10.8"
+blake2 = "0.10.*"
+k256 = { version = "0.13.*", features = ["arithmetic", "ecdsa"] }


### PR DESCRIPTION
# What ❔

Ported commit from the v1.5.0 to v1.4.1

## Why ❔

It's required by zksync-era
