### PR TITLE
Add EC-related and modexp precompile addresses and packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ blake2 = "0.10.*"
 k256 = { version = "0.13.*", features = ["arithmetic", "ecdsa"] }
 p256 = { version = "0.13.*", features = ["arithmetic", "ecdsa"] }
 serde = { version = "1", features = ["derive"] }
+
+pairing_ce = { git = "https://github.com/matter-labs/pairing.git" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub use k256;
 pub use p256;
 pub use sha2;
 pub use sha3;
+pub use pairing_ce as bn254;
 
 pub use self::definitions::*;
 pub use self::imm_mem_modifiers::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,9 @@ pub use blake2;
 pub use ethereum_types;
 pub use k256;
 pub use p256;
+pub use pairing_ce as bn254;
 pub use sha2;
 pub use sha3;
-pub use pairing_ce as bn254;
 
 pub use self::definitions::*;
 pub use self::imm_mem_modifiers::*;

--- a/src/system_params.rs
+++ b/src/system_params.rs
@@ -164,4 +164,6 @@ lazy_static! {
         Address::from_low_u64_be(ECMUL_INNER_FUNCTION_PRECOMPILE_ADDRESS as u64);
     pub static ref ECPAIRING_PRECOMPILE_FORMAL_ADDRESS: Address =
         Address::from_low_u64_be(ECPAIRING_INNER_FUNCTION_PRECOMPILE_ADDRESS as u64);
+    pub static ref MODEXP_PRECOMPILE_FORMAL_ADDRESS: Address =
+        Address::from_low_u64_be(MODEXP_INNER_FUNCTION_PRECOMPILE_ADDRESS as u64);
 }

--- a/src/system_params.rs
+++ b/src/system_params.rs
@@ -158,4 +158,10 @@ lazy_static! {
         Address::from_low_u64_be(SECP256R1_VERIFY_PRECOMPILE_ADDRESS as u64);
     pub static ref FRI_PROOF_VERIFY_ORACLE_PRECOMPILE_FORMAL_ADDRESS: Address =
         Address::from_low_u64_be(ADDRESS_FRI_PROOF_VERIFY_ORACLE as u64);
+    pub static ref ECADD_PRECOMPILE_FORMAL_ADDRESS: Address =
+        Address::from_low_u64_be(ECADD_INNER_FUNCTION_PRECOMPILE_ADDRESS as u64);
+    pub static ref ECMUL_PRECOMPILE_FORMAL_ADDRESS: Address =
+        Address::from_low_u64_be(ECMUL_INNER_FUNCTION_PRECOMPILE_ADDRESS as u64);
+    pub static ref ECPAIRING_PRECOMPILE_FORMAL_ADDRESS: Address =
+        Address::from_low_u64_be(ECPAIRING_INNER_FUNCTION_PRECOMPILE_ADDRESS as u64);
 }

--- a/src/system_params.rs
+++ b/src/system_params.rs
@@ -24,9 +24,14 @@ pub const INITIAL_FRAME_FORMAL_EH_LOCATION: u16 = u16::MAX;
 
 const SYSTEM_CONTRACTS_OFFSET_ADDRESS: u16 = 1 << 15;
 
+// The following constants are the addresses of the precompiles
 pub const KECCAK256_ROUND_FUNCTION_PRECOMPILE_ADDRESS: u16 = SYSTEM_CONTRACTS_OFFSET_ADDRESS + 0x10;
 pub const SHA256_ROUND_FUNCTION_PRECOMPILE_ADDRESS: u16 = 0x02; // as in Ethereum
 pub const ECRECOVER_INNER_FUNCTION_PRECOMPILE_ADDRESS: u16 = 0x01; // as in Ethereum
+pub const MODEXP_INNER_FUNCTION_PRECOMPILE_ADDRESS: u16 = 0x05; // as in Ethereum
+pub const ECADD_INNER_FUNCTION_PRECOMPILE_ADDRESS: u16 = 0x06; // as in Ethereum
+pub const ECMUL_INNER_FUNCTION_PRECOMPILE_ADDRESS: u16 = 0x07; // as in Ethereum
+pub const ECPAIRING_INNER_FUNCTION_PRECOMPILE_ADDRESS: u16 = 0x08; // as in Ethereum
 pub const SECP256R1_VERIFY_PRECOMPILE_ADDRESS: u16 = 0x100; // As in RIP7212: https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md
 
 pub const MAX_PUBDATA_COST_PER_QUERY: i32 = 65;


### PR DESCRIPTION
# What ❔

This pull request adds the following precompile addresses:
- `modexp`: `0x05`;
- `ecadd`: `0x06`;
- `ecmul`: `0x07`;
- `ecpairing`: `0x08`.

## Why ❔

They are, for now, not included in the list of precompile addresses, thus the PR.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
  - There is no need for tests 
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
